### PR TITLE
Removal of Redundant MIT License Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,3 @@ We constantly evaluate embedding models using standardized benchmarks (higher is
 VectorDB is also optimized for speed of retrieval. We automatically uses [Faiss](https://github.com/facebookresearch/faiss) for low number of chunks (<4000) and [mrpt](https://github.com/vioshyvo/mrpt) for high number of chunks to ensure maximum performance across the spectrum of use cases.
 
 ![Vector search engine comparison](images/comparison.png)
-
-## License
-
-MIT License.


### PR DESCRIPTION
Hey Kenneth,
I've submitted a pull request for your repository regarding the README file. I noticed a redundant mention of the MIT License at the end of the README, as it was already linked at the top through the PNG image.

I've removed the duplicate MIT License text from the end of the file to streamline the README and avoid redundancy. Please review the pull request and consider merging it into the main branch.

Thank you.